### PR TITLE
Update cwff.py

### DIFF
--- a/cwff.py
+++ b/cwff.py
@@ -590,6 +590,8 @@ def main_logic(site, args):
 			if not os.path.isdir(args.o):
 				os.mkdir(args.o)
 			outdir = args.o
+		else:
+			os.mkdir(outdir)
 
 		with open(os.path.join(outdir,"endpoints.txt"), "w") as f:
 			for line in sorted(collect.endpoints):


### PR DESCRIPTION
Running with default directory name causes FileNotFoundError, because the program didn't create a default directory, so this is a quick fix.